### PR TITLE
Added option to create partitioned tables without primary key

### DIFF
--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -7,16 +7,16 @@ use Illuminate\Database\Schema\Blueprint as IlluminateBlueprint;
 class Blueprint extends IlluminateBlueprint
 {
     /**
-     * Column key one for creating a composite key for a range partitioned table.
+     * Column key one for creating a composite key for a range partitioned table. Use NULL if table has no primary key
      *
-     * @var string
+     * @var string|null
      */
     public $pkCompositeOne;
 
     /**
-     * Column key two for creating a composite key for range partitioned table.
+     * Column key two for creating a composite key for range partitioned table. Use NULL if table has no primary key
      *
-     * @var string
+     * @var string|null
      */
     public $pkCompositeTwo;
 

--- a/src/Database/Schema/Builder.php
+++ b/src/Database/Schema/Builder.php
@@ -23,13 +23,13 @@ class Builder extends IlluminateBuilder
      *
      * @param string $table
      * @param Closure $callback
-     * @param string $pkCompositeOne
-     * @param string $pkCompositeTwo
+     * @param string|null $pkCompositeOne
+     * @param string|null $pkCompositeTwo
      * @param string $rangeKey
      * @return void
      * @throws BindingResolutionException
      */
-    public function createRangePartitioned(string $table, Closure $callback, string $pkCompositeOne, string $pkCompositeTwo, string $rangeKey)
+    public function createRangePartitioned(string $table, Closure $callback, ?string $pkCompositeOne = null, ?string $pkCompositeTwo = null, string $rangeKey)
     {
         $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback, $pkCompositeOne, $pkCompositeTwo, $rangeKey) {
             $blueprint->createRangePartitioned();

--- a/src/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Database/Schema/Grammars/PostgresGrammar.php
@@ -17,9 +17,15 @@ class PostgresGrammar extends IlluminatePostgresGrammar
      */
     public function compileCreateRangePartitioned(Blueprint $blueprint, Fluent $command)
     {
+        $columns = implode(', ', $this->getColumns($blueprint));
+
+        if ($blueprint->pkCompositeOne && $blueprint->pkCompositeTwo) {
+            $columns = sprintf('%s, %s', $columns, sprintf('primary key (%s, %s)', $blueprint->pkCompositeOne, $blueprint->pkCompositeTwo));
+        }
+
         return array_values(array_filter(array_merge([sprintf('create table %s (%s) partition by range (%s)',
             $this->wrapTable($blueprint),
-            sprintf('%s, %s', implode(', ', $this->getColumns($blueprint)), sprintf('primary key (%s, %s)', $blueprint->pkCompositeOne, $blueprint->pkCompositeTwo)),
+            $columns,
             $blueprint->rangeKey
         )], $this->compileAutoIncrementStartingValues($blueprint))));
     }

--- a/src/Support/Facades/Schema.php
+++ b/src/Support/Facades/Schema.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 /**
  * Range partitioning related methods.
- * @method static  createRangePartitioned(string $table, \Closure $callback, string $pkCompositeOne, string $pkCompositeTwo, string $rangeKey)
+ * @method static  createRangePartitioned(string $table, \Closure $callback, ?string $pkCompositeOne = null, ?string $pkCompositeTwo = null, string $rangeKey)
  * @method static  createRangePartition(string $table, \Closure $callback, string $suffixForPartition, string $startDate, string $endDate)
  * @method static  attachRangePartition(string $table, \Closure $callback, string $partitionTableName, string $startDate, string $endDate)
  * @method static  getAllRangePartitionedTables()


### PR DESCRIPTION
Often in datawarehouses there are tables that have no primary key, they rather use a unique constraint on many dimension foreign keys. TO be able to deal with these tables this PR adds the possibility to create partitioned tables without primary key.

The `pkCompositeOne` and `pkCompositeTwo` parameters are nullable but not rearranged in the method due to backwards compatibility.